### PR TITLE
Update lint rule and lint fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,7 @@ module.exports = {
         'default-case': 'error',
         'default-case-last': 'error',
         'default-param-last': 'error',
-        'dot-location': 'error',
+        'dot-location': 'off',
         'dot-notation': 'error',
         'eol-last': 'off',
         'eqeqeq': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     'env': {
         'es2021': true,
-        'node': true
+        'node': true,
+        'mocha': true
     },
     'extends': 'eslint:recommended',
     'parserOptions': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
     'env': {
         'es2021': true,
-        'node': true,
-        'mocha': true
+        'mocha': true,
+        'node': true
     },
     'extends': 'eslint:recommended',
     'parserOptions': {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gen-doc": "./node_modules/.bin/apidoc -i src/ -o doc/",
     "open-doc": "node ./scripts/open.js",
     "doc": "npm run gen-doc && npm run open-doc",
-    "lint": "./node_modules/.bin/eslint \"src/**\""
+    "lint": "./node_modules/.bin/eslint \"src/**\" \"tests/**\" --fix"
   },
   "keywords": [
     "Xendit"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "nyc mocha tests",
+    "test": "npm run lint && nyc mocha tests",
     "start": "node index.js",
     "gen-doc": "./node_modules/.bin/apidoc -i src/ -o doc/",
     "open-doc": "node ./scripts/open.js",

--- a/src/app.js
+++ b/src/app.js
@@ -55,7 +55,7 @@ module.exports = (db) => {
 
         var values = [req.body.start_lat, req.body.start_long, req.body.end_lat, req.body.end_long, req.body.rider_name, req.body.driver_name, req.body.driver_vehicle];
         
-        const result = db.run('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values, function (err) {
+        db.run('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values, function (err) {
             if (err) {
                 return res.send({
                     error_code: 'SERVER_ERROR',

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -10,7 +10,7 @@ const buildSchemas = require('../src/schemas');
 
 describe('API tests', () => {
     before((done) => {
-        db.serialize((err) => { 
+        db.serialize((err) => {
             if (err) {
                 return done(err);
             }
@@ -23,10 +23,10 @@ describe('API tests', () => {
 
     describe('GET /health', () => {
         it('should return health', (done) => {
-            request(app)
-                .get('/health')
-                .expect('Content-Type', /text/)
-                .expect(200, done);
+            request(app).
+                get('/health').
+                expect('Content-Type', /text/u).
+                expect(200, done);
         });
     });
 });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -23,10 +23,10 @@ describe('API tests', () => {
 
     describe('GET /health', () => {
         it('should return health', (done) => {
-            request(app).
-                get('/health').
-                expect('Content-Type', /text/u).
-                expect(200, done);
+            request(app)
+                .get('/health')
+                .expect('Content-Type', /text/u)
+                .expect(200, done);
         });
     });
 });


### PR DESCRIPTION
## What
This PR include updating lint configuration and also lint fixes.

Updated lint configuration included:
- Including mocha env
- Turn off `dot-location` rule
- Test script include lint testing

## Why
- Enabling mocha env: So that test functions such as `before`, `describe` and `it` would not throw lint error
- Turning off `dot-location` rule because it's easier on the eye to read function chains
