### PR TITLE
Implement pagination for list rides

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ const db = new sqlite3.Database(':memory:');
 
 const buildSchemas = require('./src/schemas');
 
+const seed = require('./src/seed');
+
 const appConfig = require('./src/app');
 
 const logger = require('./src/logger.js');
 
 db.serialize(() => {
   buildSchemas(db);
-
-  const app = appConfig(db);
-  app.listen(port, () => logger.info(`App started and listening on port ${port}`));
+  seed(db, () => {
+    const app = appConfig(db);
+    app.listen(port, () => logger.info(`App started and listening on port ${port}`));
+  });
 });

--- a/src/apidoc.js
+++ b/src/apidoc.js
@@ -28,13 +28,13 @@
  * @apiGroup Ride
  * @apiDescription Create a new ride. This endpoint return list of ride where ID is the created ride ID.
  *
- * @apiParam {Number{Between -90 and 90, inclusive}} start_lat Ride start latitude.
- * @apiParam {Number{Between -180 and 180, inclusive}} start_long Ride start longitude.
- * @apiParam {Number{Between -90 and 90, inclusive}} end_lat Ride end latitude.
- * @apiParam {Number{Between -180 and 180, inclusive}} end_long Ride end longitude.
- * @apiParam {String} rider_name Rider's name.
- * @apiParam {String} driver_name Driver's name.
- * @apiParam {String} driver_vehicle Driver's vehicle.
+ * @apiParam (Request body) {Number{Between -90 and 90, inclusive}} start_lat Ride start latitude.
+ * @apiParam (Request body) {Number{Between -180 and 180, inclusive}} start_long Ride start longitude.
+ * @apiParam (Request body) {Number{Between -90 and 90, inclusive}} end_lat Ride end latitude.
+ * @apiParam (Request body) {Number{Between -180 and 180, inclusive}} end_long Ride end longitude.
+ * @apiParam (Request body) {String} rider_name Rider's name.
+ * @apiParam (Request body) {String} driver_name Driver's name.
+ * @apiParam (Request body) {String} driver_vehicle Driver's vehicle.
  * 
  * @apiUse SuccessListOfRide
  */
@@ -46,6 +46,9 @@
  * @apiGroup Ride
  * @apiDescription List all rides. This endpoint return list of all rides.
  * 
+ * @apiParam (Query string) {Number} lastKey Indicates where to begin listing. This is convenient for pagination: To get the next page of results use the last key of the current page.
+ * @apiParam (Query string) {Number} limit Indicates total rides to return.
+ * 
  * @apiUse SuccessListOfRide
  */
 
@@ -56,7 +59,7 @@
  * @apiGroup Ride
  * @apiDescription List rides by ride ID. This endpoint return list of ride where ID is the provided ride ID.
  *
- * @apiParam {Number} id Ride's unique ID.
+ * @apiParam (Path parameter) {Number} id Ride's unique ID.
  *
  * @apiUse SuccessListOfRide
  */

--- a/src/apidoc.js
+++ b/src/apidoc.js
@@ -46,8 +46,8 @@
  * @apiGroup Ride
  * @apiDescription List all rides. This endpoint return list of all rides.
  * 
- * @apiParam (Query string) {Number} lastKey Indicates where to begin listing. This is convenient for pagination: To get the next page of results use the last key of the current page.
- * @apiParam (Query string) {Number} limit Indicates total rides to return.
+ * @apiParam (Query string) {Number} [lastKey=0] Indicates where to begin listing. This is convenient for pagination: To get the next page of results use the last key of the current page.
+ * @apiParam (Query string) {Number} [limit=10] Indicates total rides to return.
  * 
  * @apiUse SuccessListOfRide
  */

--- a/src/app.js
+++ b/src/app.js
@@ -79,7 +79,10 @@ module.exports = (db) => {
   });
 
   app.get('/rides', (req, res) => {
-    db.all('SELECT * FROM Rides', function (err, rows) {
+    const { lastKey = 0, limit = 10 } = req.query;
+    const params = [lastKey, limit];
+
+    db.all('SELECT * FROM Rides WHERE rideID > ? ORDER BY rideID LIMIT ?', params, function (err, rows) {
       if (err) {
         return res.status(500).send({
           error_code: 'SERVER_ERROR',

--- a/src/seed.js
+++ b/src/seed.js
@@ -2,17 +2,42 @@
 
 const rides = [
   [12.111, 34.111, 56.111, 78.111, 'Adam Grant', 'Bill Gates', 'Mazda CX-5'],
-  [12.333, 34.333, 56.333, 78.333, 'Sunder Pichai', 'Andrew Garfield', 'Toyota Vios']
+  [12.333, 34.333, 56.333, 78.333, 'Sunder Pichai', 'Andrew Garfield', 'Toyota Vios'],
+  [12.222, 34.222, 56.222, 78.222, 'Aemiliana Shuhrat', 'Wasyl Romeo', 'Yamaha Lagenda'],
+  [12.333, 34.333, 56.333, 78.333, 'Fathimath Wayna', 'Githa Sandip', 'Perodua Ativa'],
+  [12.555, 34.555, 56.555, 78.555, 'Kadmos Flavienne', 'Dragoslav Jaxon', 'Proton X-50'],
+  [12.333, 34.333, 56.333, 78.333, 'Vasudha Catellus', 'Jofre Spartacus', 'Perodua Ativa'],
+  [12.666, 34.666, 56.666, 78.666, 'Krasimira Carmelo', 'Katelin Oili', 'Mazda CX-5'],
+  [12.333, 34.333, 56.333, 78.333, 'Luken Anselmo', 'Leopoldo Ashish', 'Perodua Ativa'],
+  [12.777, 34.777, 56.777, 78.777, 'Eartha Remigiusz', 'Jeroboam Iddo', 'Perodua Ativa'],
+  [12.333, 34.333, 56.333, 78.333, 'Sanjeet Evgeni', 'Eireen Kuzey', 'Yamaha Lagenda'],
+  [12.888, 34.888, 56.888, 78.888, 'Wynne Varinius', 'Jordanes Trefor', 'Mazda CX-5'],
+  [12.333, 34.333, 56.333, 78.333, 'Marcelina Dileep', 'Avtandil Brina', 'Perodua Ativa'],
+  [12.999, 34.999, 56.999, 78.999, 'Roydon Gaspare', 'Sinikka Kasih', 'Perodua Ativa'],
+  [12.333, 34.333, 56.333, 78.333, 'Ella Atanasija', 'Briseida Kristupas', 'Yamaha Lagenda'],
+  [12.111, 34.111, 56.111, 78.111, 'Cleto Cristina', 'Bojana Siana', 'Mazda CX-5'],
+  [12.333, 34.333, 56.333, 78.333, 'Labhrás Valentín', 'Dorit Seva', 'Perodua Ativa'],
+  [12.111, 34.111, 56.111, 78.111, 'Vladimir Consuela', 'Serafim Emlyn', 'Perodua Ativa'],
+  [12.333, 34.333, 56.333, 78.333, 'Bente Erasmo', 'Kjerstin Divna', 'Toyota Vios'],
+  [12.111, 34.111, 56.111, 78.111, 'Yoshirou Leni', 'Hilal Blaženka', 'Perodua Ativa'],
+  [12.333, 34.333, 56.333, 78.333, 'Jone Turnus', 'Porunn Felinus', 'Yamaha Lagenda']
 ];
 
 module.exports = (db, done) => {
   const createRideTableSchema = 'INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)';
 
-  db.run(createRideTableSchema, rides[0], () => {
-    db.run(createRideTableSchema, rides[1], () => {
-      done();
-    });
-  });
+  let count = 0;
 
-  return db;
+  const insert = () => {
+    db.run(createRideTableSchema, rides[count], () => {
+      count += 1;
+      if (count < rides.length) {
+        insert();
+      } else {
+        done();
+      }
+    });
+  };
+
+  insert();
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -106,26 +106,83 @@ describe('API tests', () => {
     });
     
     describe('when database is not empty', () => {
-      before((done) => {
-        db.serialize(() => {
-          seed(db, done);
+      describe('and no query specified', () => {
+        before((done) => {
+          db.serialize(() => {
+            seed(db, done);
+          });
+        });
+  
+        after((done) => {
+          clearTable(db, done);
+        });
+  
+        it('by default, should return first 10 items', (done) => {
+          request(app)
+            .get('/rides')
+            .expect('Content-Type', /json/u)
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.length).to.equal(10);
+              expect(res.body[0]).to.include({ rideID: 1 });
+              expect(res.body[res.body.length - 1]).to.include({ rideID: 10 });
+            })
+            .end(done);
         });
       });
 
-      after((done) => {
-        clearTable(db, done);
+      describe('query specified, lastKey is 5 and limit is 3', () => {
+        before((done) => {
+          db.serialize(() => {
+            seed(db, done);
+          });
+        });
+  
+        after((done) => {
+          clearTable(db, done);
+        });
+  
+        it('should return 3 records starting from 6', (done) => {
+          request(app)
+            .get('/rides')
+            .query({ lastKey: 5, limit: 3 })
+            .expect('Content-Type', /json/u)
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.length).to.equal(3);
+              expect(res.body[0]).to.include({ rideID: 6 });
+              expect(res.body[res.body.length - 1]).to.include({ rideID: 8 });
+            })
+            .end(done);
+        });
       });
 
-      it('should return success', (done) => {
-        request(app)
-          .get('/rides')
-          .expect('Content-Type', /json/u)
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.length).to.equal(2);
-          })
-          .end(done);
+      describe('query specified, lastKey is 12 and limit is 7', () => {
+        before((done) => {
+          db.serialize(() => {
+            seed(db, done);
+          });
+        });
+  
+        after((done) => {
+          clearTable(db, done);
+        });
+  
+        it('should return 7 records starting from 13', (done) => {
+          request(app)
+            .get('/rides')
+            .query({ lastKey: 12, limit: 7 })
+            .expect('Content-Type', /json/u)
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.length).to.equal(7);
+              expect(res.body[0]).to.include({ rideID: 13 });
+              expect(res.body[res.body.length - 1]).to.include({ rideID: 19 });
+            })
+            .end(done);
+        });
       });
+      
     });
   });
 


### PR DESCRIPTION
## What
- Implement pagination to retrieve pages of the resource rides.
- Update document to reflect the changes of how to use the API, refer to screenshot below

## How to cross-check
To make it easier for cross-check, database is pre-populated upon spawning of the server.
1. Start the server and run these commands in the terminal
2. `curl 'localhost:8010/rides'` should return the first 10 results
3. `curl 'localhost:8010/rides?lastKey=10&limit=5'` should return 5 results starting from `rideID=11`

## Screenshots
Updated documents
<img width="1043" alt="Screenshot 2021-03-28 at 7 15 50 PM" src="https://user-images.githubusercontent.com/8358060/112750577-f2eb4400-8ffb-11eb-85ad-02283f6ad23b.png">
