### PR TITLE
Convert database callback code to use `async/await`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
     'complexity': 'off',
     'computed-property-spacing': 'error',
     'consistent-return': 'off',
-    'consistent-this': 'error',
+    'consistent-this': 'off',
     'curly': 'error',
     'default-case': 'error',
     'default-case-last': 'error',

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 const port = 8010;
 
-const sqlite3 = require('sqlite3').verbose();
-
-const db = new sqlite3.Database(':memory:');
+const db = require('./src/db');
 
 const buildSchemas = require('./src/schemas');
 
@@ -14,8 +12,8 @@ const appConfig = require('./src/app');
 
 const logger = require('./src/logger.js');
 
-db.serialize(() => {
-  buildSchemas(db);
+db.serialize(async () => {
+  await buildSchemas(db);
   seed(db, () => {
     const app = appConfig(db);
     app.listen(port, () => logger.info(`App started and listening on port ${port}`));

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ const appConfig = require('./src/app');
 
 const logger = require('./src/logger.js');
 
-db.serialize(async () => {
+(async () => {
   await buildSchemas(db);
   seed(db);
   const app = appConfig(db);
   app.listen(port, () => logger.info(`App started and listening on port ${port}`));
-});
+})();

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ const logger = require('./src/logger.js');
 
 db.serialize(async () => {
   await buildSchemas(db);
-  seed(db, () => {
-    const app = appConfig(db);
-    app.listen(port, () => logger.info(`App started and listening on port ${port}`));
-  });
+  seed(db);
+  const app = appConfig(db);
+  app.listen(port, () => logger.info(`App started and listening on port ${port}`));
 });

--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,7 @@ const jsonParser = bodyParser.json();
 module.exports = (db) => {
   app.get('/health', (req, res) => res.send('Healthy'));
 
-  app.post('/rides', jsonParser, (req, res) => {
+  app.post('/rides', jsonParser, async (req, res) => {
     const startLatitude = Number(req.body.start_lat);
     const startLongitude = Number(req.body.start_long);
     const endLatitude = Number(req.body.end_lat);
@@ -56,40 +56,25 @@ module.exports = (db) => {
     }
 
     var values = [req.body.start_lat, req.body.start_long, req.body.end_lat, req.body.end_long, req.body.rider_name, req.body.driver_name, req.body.driver_vehicle];
-        
-    db.run('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values, function (err) {
-      if (err) {
-        return res.status(500).send({
-          error_code: 'SERVER_ERROR',
-          message: 'Unknown error'
-        });
-      }
 
-      db.all('SELECT * FROM Rides WHERE rideID = ?', this.lastID, function (err, rows) {
-        if (err) {
-          return res.status(500).send({
-            error_code: 'SERVER_ERROR',
-            message: 'Unknown error'
-          });
-        }
-
-        res.send(rows);
+    try {
+      await db.asyncRun('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values);
+      const rows = await db.query('SELECT * FROM Rides WHERE rideID = ?', this.lastID);
+      res.send(rows);
+    } catch (err) {
+      return res.status(500).send({
+        error_code: 'SERVER_ERROR',
+        message: 'Unknown error'
       });
-    });
+    }
   });
 
-  app.get('/rides', (req, res) => {
+  app.get('/rides', async (req, res) => {
     const { lastKey = 0, limit = 10 } = req.query;
     const params = [lastKey, limit];
 
-    db.all('SELECT * FROM Rides WHERE rideID > ? ORDER BY rideID LIMIT ?', params, function (err, rows) {
-      if (err) {
-        return res.status(500).send({
-          error_code: 'SERVER_ERROR',
-          message: 'Unknown error'
-        });
-      }
-
+    try {
+      const rows = await db.query('SELECT * FROM Rides WHERE rideID > ? ORDER BY rideID LIMIT ?', params);
       if (rows.length === 0) {
         return res.status(404).send({
           error_code: 'RIDES_NOT_FOUND_ERROR',
@@ -98,17 +83,17 @@ module.exports = (db) => {
       }
 
       res.send(rows);
-    });
+    } catch (err) {
+      return res.status(500).send({
+        error_code: 'SERVER_ERROR',
+        message: 'Unknown error'
+      });
+    }
   });
 
-  app.get('/rides/:id', (req, res) => {
-    db.all(`SELECT * FROM Rides WHERE rideID='${req.params.id}'`, function (err, rows) {
-      if (err) {
-        return res.status(500).send({
-          error_code: 'SERVER_ERROR',
-          message: 'Unknown error'
-        });
-      }
+  app.get('/rides/:id', async (req, res) => {
+    try {
+      const rows = await db.query(`SELECT * FROM Rides WHERE rideID='${req.params.id}'`);
 
       if (rows.length === 0) {
         return res.status(404).send({
@@ -118,7 +103,12 @@ module.exports = (db) => {
       }
 
       res.send(rows);
-    });
+    } catch (err) {
+      return res.status(500).send({
+        error_code: 'SERVER_ERROR',
+        message: 'Unknown error'
+      });
+    }
   });
 
   return app;

--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,7 @@ module.exports = (db) => {
     var values = [req.body.start_lat, req.body.start_long, req.body.end_lat, req.body.end_long, req.body.rider_name, req.body.driver_name, req.body.driver_vehicle];
 
     try {
-      const { statement } = await db.asyncRun('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values);
+      const { statement } = await db.execute('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values);
       const { rows } = await db.query('SELECT * FROM Rides WHERE rideID = ?', statement.lastID);
       res.send(rows);
     } catch (err) {

--- a/src/app.js
+++ b/src/app.js
@@ -58,8 +58,8 @@ module.exports = (db) => {
     var values = [req.body.start_lat, req.body.start_long, req.body.end_lat, req.body.end_long, req.body.rider_name, req.body.driver_name, req.body.driver_vehicle];
 
     try {
-      await db.asyncRun('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values);
-      const rows = await db.query('SELECT * FROM Rides WHERE rideID = ?', this.lastID);
+      const { statement } = await db.asyncRun('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', values);
+      const { rows } = await db.query('SELECT * FROM Rides WHERE rideID = ?', statement.lastID);
       res.send(rows);
     } catch (err) {
       return res.status(500).send({
@@ -74,7 +74,7 @@ module.exports = (db) => {
     const params = [lastKey, limit];
 
     try {
-      const rows = await db.query('SELECT * FROM Rides WHERE rideID > ? ORDER BY rideID LIMIT ?', params);
+      const { rows } = await db.query('SELECT * FROM Rides WHERE rideID > ? ORDER BY rideID LIMIT ?', params);
       if (rows.length === 0) {
         return res.status(404).send({
           error_code: 'RIDES_NOT_FOUND_ERROR',
@@ -93,7 +93,7 @@ module.exports = (db) => {
 
   app.get('/rides/:id', async (req, res) => {
     try {
-      const rows = await db.query(`SELECT * FROM Rides WHERE rideID='${req.params.id}'`);
+      const { rows } = await db.query(`SELECT * FROM Rides WHERE rideID='${req.params.id}'`);
 
       if (rows.length === 0) {
         return res.status(404).send({

--- a/src/db.js
+++ b/src/db.js
@@ -16,7 +16,7 @@ db.query = function (sql, params) {
   });
 };
 
-db.asyncRun = function (sql, params) {
+db.execute = function (sql, params) {
   const dbInstance = this;
 
   return new Promise(function (resolve, reject) {

--- a/src/db.js
+++ b/src/db.js
@@ -10,7 +10,7 @@ db.query = function (sql, params) {
       if (error) {
         reject(error);
       } else {
-        resolve(rows);
+        resolve({ rows, statement: this });
       }
     });
   });
@@ -24,7 +24,7 @@ db.asyncRun = function (sql, params) {
       if (error) {
         reject(error);
       } else {
-        resolve(rows);
+        resolve({ rows, statement: this });
       }
     });
   });

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,33 @@
+const sqlite3 = require('sqlite3').verbose();
+
+const db = new sqlite3.Database(':memory:');
+
+db.query = function (sql, params) {
+  const dbInstance = this;
+
+  return new Promise(function (resolve, reject) {
+    dbInstance.all(sql, params, function (error, rows) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(rows);
+      }
+    });
+  });
+};
+
+db.asyncRun = function (sql, params) {
+  const dbInstance = this;
+
+  return new Promise(function (resolve, reject) {
+    dbInstance.run(sql, params, function (error, rows) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(rows);
+      }
+    });
+  });
+};
+
+module.exports = db;

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -16,7 +16,7 @@ module.exports = async (db) => {
         )
     `;
 
-  await db.asyncRun(createRideTableSchema);
+  await db.execute(createRideTableSchema);
 
   return db;
 };

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (db) => {
+module.exports = async (db) => {
   const createRideTableSchema = `
         CREATE TABLE Rides
         (
@@ -16,7 +16,7 @@ module.exports = (db) => {
         )
     `;
 
-  db.run(createRideTableSchema);
+  await db.asyncRun(createRideTableSchema);
 
   return db;
 };

--- a/src/seed.js
+++ b/src/seed.js
@@ -23,21 +23,10 @@ const rides = [
   [12.333, 34.333, 56.333, 78.333, 'Jone Turnus', 'Porunn Felinus', 'Yamaha Lagenda']
 ];
 
-module.exports = (db, done) => {
+module.exports = (db) => {
   const createRideTableSchema = 'INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)';
 
-  let count = 0;
-
-  const insert = () => {
-    db.run(createRideTableSchema, rides[count], () => {
-      count += 1;
-      if (count < rides.length) {
-        insert();
-      } else {
-        done();
-      }
-    });
-  };
-
-  insert();
+  rides.forEach(async (ride) => {
+    await db.asyncRun(createRideTableSchema, ride);
+  });
 };

--- a/src/seed.js
+++ b/src/seed.js
@@ -27,6 +27,6 @@ module.exports = (db) => {
   const createRideTableSchema = 'INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)';
 
   rides.forEach(async (ride) => {
-    await db.asyncRun(createRideTableSchema, ride);
+    await db.execute(createRideTableSchema, ride);
   });
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -21,16 +21,8 @@ const validRideInput = {
 };
 
 describe('API tests', () => {
-  before((done) => {
-    db.serialize((err) => {
-      if (err) {
-        return done(err);
-      }
-
-      buildSchemas(db);
-
-      done();
-    });
+  before(async () => {
+    await buildSchemas(db);
   });
 
   describe('GET /health', () => {
@@ -56,14 +48,14 @@ describe('API tests', () => {
     });
     
     describe('when ride exist', () => {
-      before((done) => {
+      before(() => {
         db.serialize(() => {
-          seed(db, done);
+          seed(db);
         });
       });
 
-      after((done) => {
-        clearTable(db, done);
+      after(async () => {
+        await clearTable(db);
       });
     
       it('should return success', (done) => {
@@ -105,14 +97,14 @@ describe('API tests', () => {
     
     describe('when database is not empty', () => {
       describe('and no query specified', () => {
-        before((done) => {
+        before(() => {
           db.serialize(() => {
-            seed(db, done);
+            seed(db);
           });
         });
   
-        after((done) => {
-          clearTable(db, done);
+        after(async () => {
+          await clearTable(db);
         });
   
         it('by default, should return first 10 items', (done) => {
@@ -130,14 +122,14 @@ describe('API tests', () => {
       });
 
       describe('query specified, lastKey is 5 and limit is 3', () => {
-        before((done) => {
+        before(() => {
           db.serialize(() => {
-            seed(db, done);
+            seed(db);
           });
         });
   
-        after((done) => {
-          clearTable(db, done);
+        after(async () => {
+          await clearTable(db);
         });
   
         it('should return 3 records starting from 6', (done) => {
@@ -156,14 +148,14 @@ describe('API tests', () => {
       });
 
       describe('query specified, lastKey is 12 and limit is 7', () => {
-        before((done) => {
+        before(() => {
           db.serialize(() => {
-            seed(db, done);
+            seed(db);
           });
         });
   
-        after((done) => {
-          clearTable(db, done);
+        after(async () => {
+          await clearTable(db);
         });
   
         it('should return 7 records starting from 13', (done) => {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -3,9 +3,7 @@
 const request = require('supertest');
 const { expect } = require('chai');
 
-const sqlite3 = require('sqlite3').verbose();
-
-const db = new sqlite3.Database(':memory:');
+const db = require('../src/db');
 
 const app = require('../src/app')(db);
 const buildSchemas = require('../src/schemas');

--- a/tests/clear-table.js
+++ b/tests/clear-table.js
@@ -4,8 +4,8 @@ module.exports = async (db) => {
   const clearTable = 'DELETE FROM Rides';
   const resetSequence = 'UPDATE sqlite_sequence SET seq = 0 WHERE name="Rides"';
 
-  await db.asyncRun(clearTable);
-  await db.asyncRun(resetSequence);
+  await db.execute(clearTable);
+  await db.execute(resetSequence);
 
   return db;
 };

--- a/tests/clear-table.js
+++ b/tests/clear-table.js
@@ -1,14 +1,11 @@
 'use strict';
 
-module.exports = (db, done) => {
+module.exports = async (db) => {
   const clearTable = 'DELETE FROM Rides';
   const resetSequence = 'UPDATE sqlite_sequence SET seq = 0 WHERE name="Rides"';
 
-  db.run(clearTable, () => {
-    db.run(resetSequence, () => {
-      done();
-    });
-  });
+  await db.asyncRun(clearTable);
+  await db.asyncRun(resetSequence);
 
   return db;
 };


### PR DESCRIPTION
## What
- Convert callback style code to use `async/await`, codes are generally more cleaner too read and maintain in this style.
- Added 2 new functions to `db` that can be used for `async/await`
- `db.query` is the `async/await` version of `db.all`
- `db.execute` is the `async/await` version of `db.run`

## Why
With these two keywords, we can, as the name implies, await on a promise. We could avoid callback hell, allow our codes to be structured in a more concise, clean and synchronous way. The additional db functions would help us to chain queries in a cleaner way.

Callback example:
```js
db.all('SQL QUERY', (err, rows) => {
  db.all('SQL QUERY', (err, rows) => {
    db.run('SQL QUERY', (err, rows) => {
    });
  });
});
```

async/await example:
```js
await db.query('SQL QUERY');
await db.query('SQL QUERY');
await db.execute('SQL QUERY');
```

## How
The secret sauce lies in `db.js` where sqlite functions are being promisified, so that we could use `async/await` on it.
If the promise is successfully resolved, it would return two parameters:
- `rows`: The rows return from the query itself
- `statement`: The statement object generated after running the query. This statement object consist of important value such as the `lastID`. The `lastID` represent the id that is generated by inserting a new record into the database.