### PR TITLE
Prevent SQL Injection

### DIFF
--- a/src/handlers/get-rides-by-id.js
+++ b/src/handlers/get-rides-by-id.js
@@ -2,7 +2,8 @@ const db = require('../db');
 
 module.exports = async (req, res) => {
   try {
-    const { rows } = await db.query(`SELECT * FROM Rides WHERE rideID='${req.params.id}'`);
+    const params = [req.params.id];
+    const { rows } = await db.query('SELECT * FROM Rides WHERE rideID = ?', params);
 
     if (rows.length === 0) {
       return res.status(404).send({


### PR DESCRIPTION
## What
Instead of constructing a string of SQL mixed with request parameters, used `?` in query to designate places where parameters will be substituted when the SQL statement is executed. SQLite automatically treats the data as input data and it does not interfere with parsing the actual SQL statement.

## Why
Prevent SQL Injection. Attackers might use this exposure to gain benefit for themselves.
